### PR TITLE
Fix: Correct pykiwoom method names in kiwoom_api.py

### DIFF
--- a/kiwoom_api.py
+++ b/kiwoom_api.py
@@ -21,7 +21,7 @@ class KiwoomAPI:
                 self.app = QApplication(sys.argv)
             
             self.kiwoom = Kiwoom()
-            self.kiwoom.comm_connect()
+            self.kiwoom.CommConnect()
             
             # 로그인 완료까지 대기
             while not self.kiwoom.get_connect_state():
@@ -337,6 +337,6 @@ class KiwoomAPI:
     def disconnect(self):
         """연결 해제"""
         if self.kiwoom:
-            self.kiwoom.comm_terminate()
+            self.kiwoom.CommTerminate()
         if self.app:
             self.app.quit()


### PR DESCRIPTION
I replaced incorrect method names for the pykiwoom library.
- I changed `comm_connect` to `CommConnect` in the `connect` method.
- I changed `comm_terminate` to `CommTerminate` in the `disconnect` method.

These changes address an AttributeError that occurred when running main.py due to the incorrect method calls.